### PR TITLE
Closes #108 - Fixed mark_report_complete and sign_off_report view met…

### DIFF
--- a/Templates/read_only_report.html
+++ b/Templates/read_only_report.html
@@ -298,6 +298,35 @@
                         </div>
                     </div>
                     <div style="padding: 30px;border-radius: 10px;box-shadow: 0px 5px 10px 1px rgba(33,37,41,0.2);padding-bottom: 40px;margin-top: 15px;margin-bottom: 15px;">
+                        <div class="row" style="margin-top: 20px">
+                            <div class="col-12">
+                                <p>Automatically Generated Information</p>
+                            </div>
+                            <div class="col-6">
+                                <label> Report Status: </label>
+                                <input type="text" value="{{ report.report_status }}" disabled>
+                            </div>
+                            <div class="col-6">
+                                <label> Report Submission Date: </label>
+                                <input type="datetime-local" value="{{ report.report_submission_date|date:"Y-m-d\TH:i" }}" disabled>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12">
+                                <label> Reporting Account: </label>
+                                <input type="text" value="{{ report.reporter_account }}" disabled>
+                            </div>
+                            <div class="col-12">
+                                <label> Reviewing Physician's Account: </label>
+                                <input type="text" value="{{ report.physician_review_account }}" disabled>
+                            </div>
+                            <div class="col-12">
+                                <label> Supervising Reviewer's Account: </label>
+                                <input type="text" value="{{ report.completing_account }}" disabled>
+                            </div>
+                        </div>
+                    </div>
+                    <div style="padding: 30px;border-radius: 10px;box-shadow: 0px 5px 10px 1px rgba(33,37,41,0.2);padding-bottom: 40px;margin-top: 15px;margin-bottom: 15px;">
                         <div class="col">
                             <p style="color: var(--bs-red);font-style: italic;text-decoration:  underline;">SIGNATURES HERE (FORMAT/PROTOCOL TO BE DETERMINED)</p>
                         </div>
@@ -306,6 +335,8 @@
                             </div>
                             <div class="col-12"><textarea class="form-control form-control-lg" name="physician_comments" disabled>{{ report.physician_comments }}</textarea></div>
                         </div>
+                    </div>
+                    <div style="padding: 30px;border-radius: 10px;box-shadow: 0px 5px 10px 1px rgba(33,37,41,0.2);padding-bottom: 40px;margin-top: 15px;margin-bottom: 15px;">
                         <div class="row" style="margin-top: 20px">
                             <div class="col-4">
                                 <a href="/edit_report/{{ report.id }}">

--- a/app/views.py
+++ b/app/views.py
@@ -141,9 +141,12 @@ def mark_report_complete(request, report_id):
         report = Report.objects.filter(id=report_id)[0]
         if report.report_status == "SU":
             report.report_status = "CO"
+            report.completing_account = request.user.username
             report.save()
+            messages.add_message(request, messages.SUCCESS, 'Incident Report Form Successfully Marked as Complete')
+            return redirect('read_report', report_id=report_id)
         else:
-            messages.error(request, f'Report cannot be marked as complete')
+            messages.add_message(request, messages.WARNING, f'Incident Report Form Cannot be Marked as Complete, Report Status:  { report.report_status }')
             return redirect('read_report', report_id=report_id)
     else:
         messages.error(request, f'User is not authenticated')
@@ -155,9 +158,12 @@ def sign_off_report(request, report_id):
         report = Report.objects.filter(id=report_id)[0]
         if report.report_status == "PP":
             report.report_status = "SU"
+            report.physician_review_account = request.user.username
             report.save()
+            messages.add_message(request, messages.SUCCESS, 'Incident Report Form Successfully Signed Off')
+            return redirect('read_report', report_id=report_id)
         else:
-            messages.error(request, f'Cannot sign off on report')
+            messages.add_message(request, messages.WARNING, f'Incident Report Form Cannot be Signed Off, Report Status:  { report.report_status }')
             return redirect('read_report', report_id=report_id)
     else:
         messages.error(request, f'User is not authenticated')


### PR DESCRIPTION
…hods

Added redirects to mark_report_complete and sign_off_report views, as well as more descriptive error messages and adding the username of the account that marked the report as complete and signed off on the report.

Added additional information to be displayed on the read_only_report.html template. This includes report status, submission date (Automatically generated when first saved/submitted), and the username of those attached to the report.